### PR TITLE
Fix deprecated ord() for PHP 8.4+

### DIFF
--- a/lib/LongitudeOne/Geo/WKB/Reader.php
+++ b/lib/LongitudeOne/Geo/WKB/Reader.php
@@ -68,9 +68,8 @@ class Reader
         $this->position = 0;
         $this->previous = 0;
 
-        if (ord($input) < 32) {
+        if (ord($input[0]) < 32) {
             $this->input = $input;
-
             return;
         }
 


### PR DESCRIPTION
Fix for PHP 8.4+.
`Deprecated: ord(): Providing a string that is not one byte long is deprecated. Use ord($str[0]) instead`